### PR TITLE
API error handling

### DIFF
--- a/public/js/watchlist.js
+++ b/public/js/watchlist.js
@@ -84,16 +84,21 @@ $(document).ready(function () {
     createNewList()
   })
 
-  $('#searchForm').on('click', function (event) {
+  $('#searchForm').on('submit', function (event) {
     event.preventDefault()
     var ticker = $('#tickerInput').val()
     $('#tickerInput').val('')
     const isRegexTrue = /^[a-zA-Z]+$/.test(ticker)
     if (!isRegexTrue) {
-      console.log('Invalid search input')
+      $('#watchlistContent').empty()
+      $('#watchlistContent').html('Invalid search input')
     } else {
       $.ajax('/api/watchlist/search/' + ticker, {
-        type: 'GET'
+        type: 'GET',
+        error: function (err) {
+          $('#watchlistContent').empty()
+          $('#watchlistContent').html(err.statusText + ': Invalid symbol')
+        }
       }).then(
         function (response) {
           createMessage(response)

--- a/public/js/watchlist.js
+++ b/public/js/watchlist.js
@@ -23,7 +23,6 @@ $(document).ready(function () {
       })
       listSelect = []
       listSelect = array
-      console.log(array)
       initializeRows(array)
     })
   }

--- a/public/js/watchlist.js
+++ b/public/js/watchlist.js
@@ -110,7 +110,12 @@ $(document).ready(function () {
   // Handles displaying data when watchlist is clicked
   watchAside.on('click', 'li', function (event) {
     const clickedWatchlist = this.dataset.ticker
-    $.ajax('/api/watchlist/' + clickedWatchlist, function (data) {
+    $.ajax('/api/watchlist/' + clickedWatchlist, {
+      type: 'GET',
+      error: function (err) {
+        $('#watchlistContent').empty()
+        $('#watchlistContent').html(err.statusText + ': No stocks saved in the ' + clickedWatchlist + ' watchlist')
+      }
     }).then(function (response) {
       $('#watchlistContent').empty()
       const beginColumns = $('<div class="columns is-multiline" id="watchlistColumns">')

--- a/routes/api-routes.js
+++ b/routes/api-routes.js
@@ -37,6 +37,8 @@ module.exports = function (app) {
       axios.get(queryUrl)
         .then(function (result) {
           res.json(result.data)
+        }).catch(function (err) {
+          res.status(400).json(err)
         })
     })
   })

--- a/routes/api-routes.js
+++ b/routes/api-routes.js
@@ -108,6 +108,8 @@ module.exports = function (app) {
       }
       data.push(dataPoints)
       res.json(data)
+    }).catch(function (err) {
+      res.status(400).json(err)
     })
   })
   // Create new watchlist functionality

--- a/views/watchlist.html
+++ b/views/watchlist.html
@@ -84,8 +84,6 @@
         </div>
         <!-- Main Content Area -->
         <div class="column is-main-content" id="watchlistContent">
-            <button class="delete deleteBTN" aria-label="delete" data-attribute="${data.symbol}"></button>
-
         </div>
     </div>
     <script src="https://canvasjs.com/assets/script/canvasjs.min.js"></script>


### PR DESCRIPTION
Added error handling to Stock search.
If an stock input contains anything other than alpha characters, an error display "Invalid search input" is displayed in #watchlistContent.
If an api request return fails, Error 400 is logged in the back end and an error display "Bad Request: Invalid symbol" is displayed in #watchlistContent
An error clears #watchlistContent before displaying error string.